### PR TITLE
[Bug] Re subscription error

### DIFF
--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -191,6 +191,9 @@
 						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
+							com.apple.BackgroundModes = {
+								enabled = 0;
+							};
 							com.apple.HealthKit = {
 								enabled = 1;
 							};

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,6 +13,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
 
+  shared_preferences: ^0.4.2
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/ios/Classes/HealthDataUtils.swift
+++ b/ios/Classes/HealthDataUtils.swift
@@ -5,6 +5,7 @@ class HealthDataUtils: NSObject {
     
     static let global = HealthDataUtils()
     static var healthStore: HKHealthStore?
+    static var subscriptionQueries:[HKObserverQuery] = []
     let dataFetcher = HealthDataFetcher()
     var updateHandler: ((Any?, Error?) -> Void)?
     


### PR DESCRIPTION
When the user would subscribe, unsubscribe and subscribe again, the app was getting the messages 2 times (each extra loop of unsubscribe/subscribe added an additional duplicate).

This was due to the fact that while the app was blocking further background processing, the queries were not cancelled appropriately.  